### PR TITLE
release: v0.4.7 — competitive-positioning sub-agent now actually researches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.7] - 2026-05-19
+
+### Fixed
+
+- **`competitive-positioning`: sub-agent had no network tools but was dispatched to research competitors.** SKILL.md Steps 4 (LANDSCAPE_RESEARCH), 5a (MOAT_SCORING), and 5b (POSITIONING_SCORING) dispatch the sub-agent with prompts asking for `evidence_source: researched | agent_estimate` (and Step 5a's `trajectory: building/stable/eroding`, which is inherently research-dependent). The agent's `tools:` allowlist was `["Read", "Edit", "Glob", "Grep"]` — no network access — and Step 4 explicitly forbade the main thread from doing the research either. Net effect since the skill shipped: every `evidence_source: "researched"` stamp was a training-cutoff guess wearing a research label. CHECKLIST (Step 6) is unaffected (artifact grading only, no research).
+
+### Changed
+
+- **`competitive-positioning` agent now declares `WebSearch`** in its `tools:` allowlist. Cowork's named-sub-agent dispatch is strict allowlist mode — empirically verified via a probe (a sub-agent declared with `tools: [Read, Edit, Glob, Grep]` receives exactly those four names; no MCP leakage, no default-toolset injection). With `WebSearch` declared, Phase A enrichment, moat trajectory scoring, and positioning-axis evidence become honest.
+- **`competitive-positioning` SKILL.md dispatch prompts** (Steps 4, 5a, 5b) now reference `WebSearch` explicitly. The "Do not do the landscape research yourself in the main thread" instruction in Step 4 is retained — research now runs in the sub-agent's isolated context, where it belongs. Phase B (gap detection) is also instructed to use `WebSearch` for discovering missing competitor categories.
+- **Producer-script JSON schemas unchanged.** The dishonesty was upstream of `validate_landscape.py` / `score_moats.py` / `score_positioning.py`; the schemas themselves were always correct.
+
+### Added
+
+- **`tests/test_cowork_invariants.py::test_research_agents_declare_websearch`** — new regression detector. Agents in `_AGENTS_REQUIRING_WEBSEARCH` (currently `{"competitive-positioning"}`) must declare `WebSearch`. Future refactors that strip it from the allowlist will fail CI. The docstring of `test_agent_declares_no_dangerous_tools` is updated to reflect that the "all agents declare exactly Read/Edit/Glob/Grep" property no longer holds — WebSearch is an intentional addition.
+
+### Notes
+
+- The fix corrects a real defect but the diff is small (one `tools:` addition + four dispatch-prompt clarifications). The original v0.4.7 plan considered the "main-thread does research, sub-agent structures the data" pattern used by `market-sizing` and `ic-sim`, but a sub-agent probe in Cowork (`/tmp/cowork-tool-probe/` locally) settled that `WebSearch` *is* available to sub-agents — only `WebFetch` (the plain name; `mcp__workspace__web_fetch` IS available) and `Bash` (replaced by `mcp__workspace__bash` in the default sub-agent toolset, not via deferred MCP tier as the allowlist file's comment suggested) follow the documented exclusion model. A separate follow-up will correct the false-premise comments in `cowork_async_subagent_filter.py` and the sibling skill docs.
+- **No artifact schema bump.** `schema_version` strings for competitive-positioning artifacts are unchanged — consumer plugins downstream of this skill will not see a version-pin break.
+
 ## [0.4.6] - 2026-05-13
 
 ### Fixed

--- a/founder-skills/.claude-plugin/plugin.json
+++ b/founder-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "founder-skills",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Skills for startup founders by lool ventures",
   "author": {
     "name": "lool ventures",

--- a/founder-skills/agents/competitive-positioning.md
+++ b/founder-skills/agents/competitive-positioning.md
@@ -8,7 +8,9 @@ description: >
   Context A (per-step analytical, Mitigation 1): LANDSCAPE_RESEARCH,
   MOAT_SCORING, POSITIONING_SCORING, or CHECKLIST dispatch. Returns
   structured JSON that the main thread pipes through the producer script.
-  No Bash required.
+  LANDSCAPE_RESEARCH, MOAT_SCORING, and POSITIONING_SCORING use WebSearch
+  for competitor research (CHECKLIST is artifact-only, no research). No
+  Bash required.
 
   Context B (post-compose coaching, POST_COMPOSE_COACHING): reads
   coaching_payload inlined in dispatch prompt, performs Grep idempotency
@@ -16,7 +18,7 @@ description: >
   artifacts on disk, returns structured success payload. No Bash required.
 model: inherit
 color: "#E67E22"
-tools: ["Read", "Edit", "Glob", "Grep"]
+tools: ["Read", "Edit", "Glob", "Grep", "WebSearch"]
 skills: ["competitive-positioning"]
 ---
 
@@ -58,11 +60,16 @@ script (which validates schemas and persists canonical artifacts).
 Read `landscape_draft.json` and `product_profile.json` from the ANALYSIS_DIR.
 
 **Phase A — Enrich existing competitors:** For each competitor in
-`landscape_draft.json`, use available tools (Read, Glob, Grep) to enrich with:
-pricing model, funding history, team size, target customers, strengths, weaknesses.
-Record `evidence_source` per field (`"researched"` or `"agent_estimate"`). Set
-`research_depth` per competitor — MUST be one of: `"full"`, `"partial"`,
-`"founder_provided"`. All slugs MUST be kebab-case (lowercase, hyphens only).
+`landscape_draft.json`, use `WebSearch` to find: pricing model, funding history,
+team size, target customers, strengths, weaknesses. Issue separate searches per
+competitor (e.g., `"<name> pricing"`, `"<name> funding 2025 2026"`, `"<name> team
+size"`) and synthesize the result snippets. Record `evidence_source` per field:
+`"researched"` only when the value came from a WebSearch result, `"agent_estimate"`
+when you defaulted to training-cutoff knowledge. Set `research_depth` per
+competitor — `"full"` when WebSearch returned substantive results across most
+fields, `"partial"` when results were thin, `"founder_provided"` when the founder
+supplied the data verbatim and WebSearch was unnecessary. All slugs MUST be
+kebab-case (lowercase, hyphens only).
 
 **Phase B — Gap detection:** Check for missing competitor categories. Add newly
 discovered competitors to `suggested_additions[]` with `merged: false`. Do NOT
@@ -94,6 +101,11 @@ for `not_applicable`), `evidence_source`
 (`researched`/`agent_estimate`/`founder_override`), `trajectory`
 (`building`/`stable`/`eroding`).
 
+For `trajectory` and any moat where `landscape.json` evidence is thin, use
+`WebSearch` to find recent (last 12 months) signals: funding rounds, M&A,
+hiring trends, executive changes, patent filings, product launches. Stamp
+`evidence_source: "researched"` only when WebSearch supplied the signal.
+
 Return JSON matching `score_moats.py`'s input schema:
 ```json
 {
@@ -113,6 +125,14 @@ For each view in `positioning.json`, assign coordinates (0-100) for every compet
 and `_startup` on both axes. Every point needs `x_evidence`, `y_evidence`, and
 provenance source fields. Assess differentiation claims with: `verifiable` (boolean),
 `evidence`, `challenge`, `verdict` (`holds`/`partially_holds`/`does_not_hold`).
+
+The axes in `positioning.json` drive the search queries — when an axis is
+"customer support depth" or "pricing transparency," issue WebSearch queries
+targeting that specific dimension per competitor. Stamp `x_evidence_source` /
+`y_evidence_source` as `"researched"` only when the coordinate came from
+WebSearch findings; `"agent_estimate"` otherwise. For differentiation claims,
+use WebSearch to find evidence supporting or contradicting each claim before
+assigning a `verdict`.
 
 Return JSON matching `score_positioning.py`'s input schema:
 ```json
@@ -169,8 +189,8 @@ computes the summary):
 
 - Return JSON only. No prose, no markdown wrapper, no explanatory message. The
   main thread parses your final assistant message as raw JSON.
-- Do not call `Bash`, `Write`, or any tool that writes to the filesystem. Read,
-  Glob, and Grep are sufficient.
+- Do not call `Bash`, `Write`, or any tool that writes to the filesystem.
+  `Read`, `Glob`, `Grep` for artifacts; `WebSearch` for competitor research.
 - If you encounter ambiguity, include it in the relevant evidence/notes field
   rather than asking back. The main thread doesn't expect mid-step questions.
 

--- a/founder-skills/skills/competitive-positioning/SKILL.md
+++ b/founder-skills/skills/competitive-positioning/SKILL.md
@@ -218,7 +218,7 @@ This avoids `Operation not permitted` errors that occur when writing to
 
 ### Step 4: Research & Enrich Competitors -> `landscape_enriched.json` -> `landscape.json` (Context A: LANDSCAPE_RESEARCH dispatch)
 
-**Dispatch the competitive-positioning sub-agent in Context A (LANDSCAPE_RESEARCH).** Do not do the landscape research yourself in the main thread — dispatch it via the `Task` tool so the research runs in an isolated context.
+**Dispatch the competitive-positioning sub-agent in Context A (LANDSCAPE_RESEARCH).** The sub-agent declares `WebSearch` in its tool allowlist (v0.4.7+) and performs the research itself — dispatch it via the `Task` tool so the research runs in an isolated context.
 
 **Dispatch prompt template:**
 
@@ -231,14 +231,18 @@ You are the competitive-positioning agent dispatched in Context A (LANDSCAPE_RES
 Read landscape_draft.json at <ANALYSIS_DIR>/landscape_draft.json and
 product_profile.json at <ANALYSIS_DIR>/product_profile.json.
 
-Phase A — Enrich existing competitors: For each competitor in landscape_draft.json, use
-available tools to find: pricing model, funding history, team size, target customers,
-strengths, weaknesses. Record evidence_source per field (researched or agent_estimate).
-Set research_depth per competitor — MUST be one of: full, partial, or founder_provided.
+Phase A — Enrich existing competitors: For each competitor in landscape_draft.json,
+use WebSearch to find pricing model, funding history, team size, target customers,
+strengths, weaknesses. Issue separate searches per competitor as needed. Record
+evidence_source per field: "researched" only when the value came from a WebSearch
+result; "agent_estimate" when you fell back to training-cutoff knowledge.
+Set research_depth per competitor — MUST be one of: full, partial, or
+founder_provided.
 
 Phase B — Gap detection: After enriching, check for missing competitor categories.
-If new competitors are found, add them to suggested_additions[] with merged: false.
-Do NOT add to competitors[] — only to suggested_additions[].
+Use WebSearch ("<product category> competitors", "<adjacent category> tools", etc.)
+to discover competitors absent from the draft. Add them to suggested_additions[]
+with merged: false. Do NOT add to competitors[] — only to suggested_additions[].
 
 Return JSON only — exactly the shape expected by validate_landscape.py:
 {
@@ -301,6 +305,11 @@ Each moat: status (strong/moderate/weak/absent/not_applicable), evidence (requir
 evidence_source (researched/agent_estimate/founder_override), trajectory
 (building/stable/eroding).
 
+For trajectory and any moat where landscape.json evidence is thin, use WebSearch
+to find recent (last 12 months) signals — funding rounds, M&A, hiring, executive
+changes, patent filings, product launches. Stamp evidence_source: "researched"
+only when the signal came from a WebSearch result.
+
 Return JSON only — exactly the shape expected by score_moats.py:
 {
   "moat_assessments": {
@@ -326,6 +335,13 @@ For each view in positioning.json, assign coordinates (0-100) for every competit
 and _startup on both axes. Every point needs x_evidence, y_evidence, and provenance.
 Assess differentiation claims: verifiable (boolean), evidence, challenge, verdict
 (holds/partially_holds/does_not_hold).
+
+The axes themselves drive the search queries — when an axis is "customer support
+depth" or "pricing transparency," issue WebSearch queries targeting that specific
+dimension per competitor. Stamp x_evidence_source / y_evidence_source as
+"researched" only when the coordinate came from a WebSearch result. For each
+differentiation_claim, use WebSearch to find supporting or contradicting evidence
+before assigning a verdict.
 
 Return JSON only — exactly the shape expected by score_positioning.py:
 {

--- a/founder-skills/tests/test_cowork_invariants.py
+++ b/founder-skills/tests/test_cowork_invariants.py
@@ -95,8 +95,12 @@ def test_agent_declares_no_dangerous_tools(agent_path: Path) -> None:
     register the name, don't declare it." See
     cowork-architecture-and-v0.4.x-learning.md.
 
-    All 5 v0.4.4 agents declare exactly Read/Edit/Glob/Grep — none of these
-    are in the dangerous set. This test exists to keep that property.
+    Through v0.4.6 all 5 agents declared exactly Read/Edit/Glob/Grep — none
+    of these are in the dangerous set. v0.4.7 added WebSearch to the
+    competitive-positioning agent's allowlist (WebSearch resolves in
+    Cowork's sub-agent registry; see probe results in v0.4.7 release notes).
+    Other additions to non-dangerous declared tool sets are OK; additions of
+    names in _DANGEROUS_IF_DECLARED are what this test catches.
     """
     fm = _parse_frontmatter(agent_path)
     declared = set(fm.get("tools", []))
@@ -108,4 +112,44 @@ def test_agent_declares_no_dangerous_tools(agent_path: Path) -> None:
         f"aren't exposed to sub-agents). Either remove from `tools:` "
         f"or document why the agent will never run as a Cowork sub-agent. "
         f"See cowork-architecture-and-v0.4.x-learning.md."
+    )
+
+
+# Agents whose SKILL.md dispatch prompts instruct them to research
+# competitors, markets, etc. via WebSearch. These MUST declare WebSearch in
+# their tools allowlist — Cowork's named-sub-agent dispatch is strict
+# allowlist mode (empirically verified v0.4.7: a sub-agent declared with
+# tools: [Read, Edit, Glob, Grep] receives EXACTLY those four names, no MCP
+# leakage, no default-toolset injection). Undeclared = unavailable.
+#
+# Adding/removing an agent here is intentional — call it out in CHANGELOG.
+_AGENTS_REQUIRING_WEBSEARCH: frozenset[str] = frozenset(
+    {
+        "competitive-positioning",
+    }
+)
+
+
+@pytest.mark.parametrize("agent_stem", sorted(_AGENTS_REQUIRING_WEBSEARCH), ids=lambda s: s)
+def test_research_agents_declare_websearch(agent_stem: str) -> None:
+    """v0.4.7 regression detector: agents whose dispatch prompts reference
+    WebSearch must declare it. Without the declaration, the sub-agent's
+    Phase-A enrichment / moat trajectory / positioning evidence steps
+    silently degrade to training-cutoff guesses stamped as `researched`.
+    See v0.4.7 release notes and the named-agent probe in
+    /tmp/cowork-tool-probe/.
+    """
+    agent_path = AGENTS_DIR / f"{agent_stem}.md"
+    assert agent_path.exists(), (
+        f"agent {agent_stem} not found at {agent_path} — update _AGENTS_REQUIRING_WEBSEARCH or rename the agent file"
+    )
+    fm = _parse_frontmatter(agent_path)
+    declared = set(fm.get("tools", []))
+    assert "WebSearch" in declared, (
+        f"{agent_stem}.md SKILL.md dispatch prompts reference WebSearch "
+        f"for competitor/market research, but the agent's `tools:` "
+        f"declaration is {sorted(declared)} — WebSearch missing. Cowork's "
+        f"named-sub-agent dispatch is strict allowlist mode; undeclared "
+        f"tools don't bind. Add 'WebSearch' to the tools list or remove "
+        f"the WebSearch references from the dispatch prompts."
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "founder-skills"
-version = "0.4.6"
+version = "0.4.7"
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = ["openpyxl"]


### PR DESCRIPTION
## Summary

- **Fixed:** `competitive-positioning` Steps 4 (LANDSCAPE_RESEARCH), 5a (MOAT_SCORING), and 5b (POSITIONING_SCORING) dispatched the sub-agent to research competitors, but the agent's `tools:` allowlist was `[Read, Edit, Glob, Grep]` — no network access. Since the skill shipped, every \`evidence_source: \"researched\"\` stamp was a training-cutoff guess wearing a research label. CHECKLIST (Step 6) is unaffected.
- **Changed:** added `WebSearch` to the agent's `tools:` allowlist. SKILL.md dispatch prompts updated to reference WebSearch explicitly. Producer-script JSON schemas unchanged — the dishonesty was upstream.
- **Added:** `tests/test_cowork_invariants.py::test_research_agents_declare_websearch` regression detector — locks WebSearch into the allowlist so future refactors can't silently strip it.

## Empirical basis

Two probes in `/tmp/cowork-tool-probe/` (local, not committed):

1. **General-purpose sub-agent probe**: shows the default Cowork sub-agent toolset includes `WebSearch`, `mcp__workspace__web_fetch`, `mcp__workspace__bash`, and the file/search primitives. Refutes the `market-sizing/SKILL.md:37` claim that sub-agents have no network access.
2. **Named sub-agent probe**: dispatched the v0.4.6 competitive-positioning agent (declared `[Read, Edit, Glob, Grep]`) and inspected its `tools_self_inventory`. Result: exactly those four — no MCP leakage, no default-toolset injection. Cowork's named-sub-agent dispatch is **strict allowlist mode**.

The fix follows directly: declare `WebSearch` in the agent allowlist, and the existing dispatch prompts become honest.

## Out of scope (separate follow-up)

The `cowork_async_subagent_filter.py:62-67` comment and the `market-sizing` / `ic-sim` SKILL.md / agent files contain false-premise statements about sub-agent network access. A separate PR will correct those without changing `market-sizing`'s architecture (main-thread research can stay as a deliberate choice — just rewrite the wrong justification).

## Test plan

- [x] `uv run pytest founder-skills/tests/ -v -m "not e2e"` — 1129 passed (all green)
- [x] `uv run ruff check .` and `uv run mypy founder-skills/tests/` — clean
- [ ] **Manual e2e dispatch on this PR**: per CLAUDE.md "When to manually dispatch e2e on a PR," this PR touches `agents/competitive-positioning.md` AND `skills/competitive-positioning/SKILL.md` — architectural surface. Will run `gh workflow run skill-quality.yml --ref fix/v0.4.7-competitive-research` and wait for green before merging.
- [ ] After merge: tag \`v0.4.7\` on the merge commit, wait for \`deck-review-e2e-smoke\` green, then \`./scripts/sync-test-repo.sh\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)