### PR TITLE
deck-review: read spelled-out counts, and convert PowerPoint via Keynote or PowerPoint when LibreOffice is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ deck: the founder count, the patent count and the CEO's tenure never reached the
 section in either run. They are now recorded exactly as printed and checked like any other
 figure, so "three organizations" on one slide can be held against "3 customers" on another.
 
+**A PowerPoint deck gets its design reviewed on a laptop without LibreOffice.** The review
+converts `.pptx` to PDF so it can see the slides; until now only LibreOffice could do that, and
+without it the five design criteria were silently set aside. It now also uses Keynote on a Mac
+and PowerPoint on Windows, whichever is installed, and still falls back to the text-only review
+when none of the three is present.
+
+### Added
+
+- **deck-review:** Step 2's PowerPoint conversion tries three converters in order, each only
+  where it is installed — LibreOffice (any OS, now including the default Windows install path),
+  Keynote via AppleScript on macOS, PowerPoint via COM on Windows — and reports `convert-failed`
+  with the converter's own error when the one it found breaks. A host with none of them takes
+  the existing text-only path unchanged. The Keynote path is measured on a real run; the
+  PowerPoint path follows Microsoft's documented `Presentations.Open` / `SaveAs(…, ppSaveAsPDF)`
+  automation and has not been exercised on a Windows host by the author.
+
 ### Fixed
 
 - **deck-review:** `ledger.py` refused a figure whose printed string was a spelled-out count

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.11.1] - 2026-09-03 — A number written in words is still a number
+
+### Highlights
+
+**Counts your deck spells out in words are now read.** "Three design partners", "six patent
+applications", "fifteen years on executive teams" — decks state their smallest and most
+checkable claims as words far more often than as digits, and the deck review either refused
+them (costing a retry) or, on the next run, left them out without saying so. Measured on a real
+deck: the founder count, the patent count and the CEO's tenure never reached the numbers
+section in either run. They are now recorded exactly as printed and checked like any other
+figure, so "three organizations" on one slide can be held against "3 customers" on another.
+
+### Fixed
+
+- **deck-review:** `ledger.py` refused a figure whose printed string was a spelled-out count
+  ("Two", "Fifteen years") as "containing no number". The refusal was right about its reason —
+  the scale check had nothing to read — and wrong about the remedy: the extraction prompt says to
+  record every number the deck states, and the slide's own string IS the words. The shared numeric
+  grammar in `reconcile.py` now reads a spelled-out cardinal (below a thousand; "a hundred",
+  "twenty-five", "three million" with the scale word left for the existing suffix table) wherever
+  a raw string prints no digit, so precision, scale, range and approximation checks see "3" where
+  the slide printed "three" while the founder-facing text keeps the words. A raw with no
+  magnitude at all ("about", "TBD", the ordinal "a fourth") is still refused.
+- **deck-review:** the LEDGER_EXTRACTION dispatch and the agent body now say so explicitly —
+  record a spelled-out count with the words as printed, never skip it, never retype it as digits.
+  Without the instruction the extractor learns from one refusal to omit the figure on the next
+  run, which is the quieter of the two failures.
+
 ## [0.11.0] - 2026-08-31 — Two instruments, one row, and a number nobody could see was wrong
 
 ### Highlights

--- a/founder-skills/.claude-plugin/plugin.json
+++ b/founder-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "founder-skills",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Skills for startup founders by lool ventures",
   "author": {
     "name": "lool ventures",

--- a/founder-skills/agents/deck-review.md
+++ b/founder-skills/agents/deck-review.md
@@ -76,6 +76,9 @@ deck does not state. Two rules carry the weight:
   `raw` keeps the slide's own string and the producer checks the two against each
   other, so a scale slip is caught rather than silently multiplying every later
   calculation by a thousand.
+  A count the slide spells out — "three design partners", "Fifteen years" — is a
+  number the deck states: record `value: 3` with `raw: "three"`, words as printed.
+  The producer reads the words; a spelled-out count is neither skipped nor retyped.
 - **`quote` is verbatim.** A second reader, who never sees your ledger, looks for that
   wording in the same extracted deck text. A quote that is not found there at all — one
   you composed, summarised, or built out of a chart you were reading — is dropped from the

--- a/founder-skills/skills/deck-review/SKILL.md
+++ b/founder-skills/skills/deck-review/SKILL.md
@@ -675,6 +675,11 @@ A slide reading "200-400m" of building height is `raw: "200-400 metres"`, not
 `k`, `b` and `t`. You are the only one who can tell these apart; nothing
 downstream can.
 
+A count the slide spells out in words is a number the deck states: "three design
+partners" is value 3 with raw "three"; "Fifteen years" is 15 with raw "Fifteen years".
+Record it with the words as printed — never skip it, never retype it as digits.
+Ordinals ("a fourth partner") and fractions are not counts; leave those out.
+
 `quote` must be the VERBATIM sentence or table row the figure was read from. It is
 re-found by a ledger-blind reader in the same extracted text; a quote that is not
 found there at all — one you composed, summarised, or read off a chart — is dropped.

--- a/founder-skills/skills/deck-review/SKILL.md
+++ b/founder-skills/skills/deck-review/SKILL.md
@@ -299,7 +299,8 @@ path rather than reporting the deck missing. Never hand-build this path — a re
 resolves against the shell's cwd, which has already moved once underneath us.
 
 **Convert a PowerPoint deck to PDF before reading it.** Design & Readability are scored from
-what a reader SEES, and only a rendered page gives you that. Today `.pptx`/`.ppt` are binary
+what a reader SEES, and only a rendered page gives you that. The block tries LibreOffice, then
+Keynote (macOS), then PowerPoint (Windows), each only where it is installed. Today `.pptx`/`.ppt` are binary
 and Read refuses them outright, so without this the slides are invisible — but do not treat
 that as the reason: if some future Read does open PowerPoint, still convert unless it returns
 actual page images, because text and structure without layout cannot support a design score.
@@ -307,25 +308,61 @@ Do this FIRST, before reading anything. Substitute the uploaded deck's path for 
 
 ```bash
 DECK_SRC="<deck path>"
-DECK_READ="$DECK_SRC"; SOFFICE=""
+DECK_READ="$DECK_SRC"; CONVERTER=""; SOFFICE=""
 case "$DECK_SRC" in
   *.pptx|*.PPTX|*.ppt|*.PPT)
     DECK_READ="no-converter"
-    for c in libreoffice soffice /Applications/LibreOffice.app/Contents/MacOS/soffice; do
-      command -v "$c" >/dev/null 2>&1 && { SOFFICE="$c"; break; }
+    B="$(basename "$DECK_SRC")"; PDF_OUT="$STAGING_DIR/${B%.*}.pdf"
+    # Three converters, tried in this order and each ONLY when it is installed: LibreOffice
+    # on any OS, Keynote on macOS, PowerPoint over COM on Windows. A host with none of them
+    # takes the text-only path below unchanged.
+    for c in libreoffice soffice /Applications/LibreOffice.app/Contents/MacOS/soffice \
+             "/c/Program Files/LibreOffice/program/soffice.exe" "${PROGRAMFILES:-}/LibreOffice/program/soffice.exe"; do
+      command -v "$c" >/dev/null 2>&1 && { SOFFICE="$c"; CONVERTER="libreoffice"; break; }
     done
-    if [ -n "$SOFFICE" ]; then
-      # -env:UserInstallation is REQUIRED: $HOME is read-only, so profile creation
-      # dies (exit 77) having converted nothing. Do not suppress errors — a silent
-      # failure is indistinguishable from having no converter, and misreports why.
-      "$SOFFICE" --headless -env:UserInstallation="file://$STAGING_DIR/.lo" \
-        --convert-to pdf --outdir "$STAGING_DIR" "$DECK_SRC" 2>&1 | tail -3
-      B="$(basename "$DECK_SRC")"
-      if [ -s "$STAGING_DIR/${B%.*}.pdf" ]; then
-        DECK_READ="$STAGING_DIR/${B%.*}.pdf"
-      else
-        DECK_READ="convert-failed"
-      fi
+    if [ -z "$CONVERTER" ] && [ -d /Applications/Keynote.app ]; then CONVERTER="keynote"; fi
+    if [ -z "$CONVERTER" ] && command -v reg.exe >/dev/null 2>&1 \
+       && reg.exe query 'HKCR\PowerPoint.Application' >/dev/null 2>&1; then CONVERTER="powerpoint"; fi
+    case "$CONVERTER" in
+      libreoffice)
+        # -env:UserInstallation is REQUIRED: $HOME is read-only, so profile creation
+        # dies (exit 77) having converted nothing. Do not suppress errors — a silent
+        # failure is indistinguishable from having no converter, and misreports why.
+        "$SOFFICE" --headless -env:UserInstallation="file://$STAGING_DIR/.lo" \
+          --convert-to pdf --outdir "$STAGING_DIR" "$DECK_SRC" 2>&1 | tail -3
+        ;;
+      keynote)
+        # Keynote imports PowerPoint and exports PDF. `launch` first: a Keynote left running
+        # headless by an earlier attempt answers every document command with "doesn't
+        # understand" (-1708) and only quitting it cures that — measured on a real run.
+        osascript - "$DECK_SRC" "$PDF_OUT" <<'KEYNOTE_EOF' 2>&1 | tail -3
+on run argv
+  tell application "Keynote"
+    launch
+    open (POSIX file (item 1 of argv))
+    delay 5
+    if (count documents) is 0 then error "Keynote opened nothing; quit Keynote and retry"
+    export document 1 to (POSIX file (item 2 of argv)) as PDF
+    close document 1 saving no
+  end tell
+end run
+KEYNOTE_EOF
+        ;;
+      powerpoint)
+        # PowerPoint over COM (ppSaveAsPDF = 32). COM wants Windows-native paths; cygpath is
+        # what Git Bash, Claude Code's shell on Windows, provides for that.
+        SRC_W="$(cygpath -w "$DECK_SRC" 2>/dev/null || printf '%s' "$DECK_SRC")"
+        DST_W="$(cygpath -w "$PDF_OUT" 2>/dev/null || printf '%s' "$PDF_OUT")"
+        powershell.exe -NoProfile -NonInteractive -Command "
+          \$app = New-Object -ComObject PowerPoint.Application
+          \$pres = \$app.Presentations.Open('$SRC_W', -1, 0, 0)
+          \$pres.SaveAs('$DST_W', 32); \$pres.Close(); \$app.Quit()" 2>&1 | tail -3
+        ;;
+    esac
+    if [ -s "$PDF_OUT" ]; then
+      DECK_READ="$PDF_OUT"
+    elif [ -n "$CONVERTER" ]; then
+      DECK_READ="convert-failed"
     fi
     ;;
 esac

--- a/founder-skills/skills/deck-review/scripts/ledger.py
+++ b/founder-skills/skills/deck-review/scripts/ledger.py
@@ -41,6 +41,7 @@ from reconcile import (  # type: ignore[import-not-found]  # noqa: E402
     MONEY,
     _precision,
     _raw_scale,
+    numeral_form,
     quote_is_identifying,
     strip_group_marks,
 )
@@ -74,7 +75,8 @@ that; keeping the floor afterwards was leftover scaffolding that only ever loose
 
 def _parsed_magnitude(raw: str) -> float | None:
     """What `raw` says the figure is, read independently of `value`."""
-    match = _NUM_RE.search(raw or "")
+    raw = numeral_form(raw)
+    match = _NUM_RE.search(raw)
     if not match or not match.group("int"):
         return None
     # Strip every grouping mark the shared mantissa admits, not just the comma: "$20 000"
@@ -97,7 +99,7 @@ def _numeric_tokens(raw: str) -> list[float]:
     numbers on the slide — so the date check compares against all of them.
     """
     out: list[float] = []
-    for match in _NUM_RE.finditer(raw or ""):
+    for match in _NUM_RE.finditer(numeral_form(raw)):
         digits = strip_group_marks(match.group("int") or "")
         if not digits:
             continue
@@ -256,6 +258,7 @@ def _ambiguous_suffix(raw: str, value: float, unit_kind: object, currency: objec
     """
     if unit_kind == MONEY or currency:
         return False
+    raw = numeral_form(raw)
     if not _BARE_SUFFIX.search(raw):
         return False
     match = _NUM_RE.search(raw)
@@ -332,9 +335,12 @@ def validate_ledger(data: dict[str, Any], total_slides: int | None = None) -> tu
         raw = fig.get("raw")
         if not isinstance(raw, str) or not raw.strip():
             errors.append(f"{where} has no raw; without the slide's own string, scale cannot be checked")
-        elif not _NUM_RE.search(raw):
-            # A `raw` WITH NO NUMBER IN IT IS NOT THE FIGURE'S PRINTED STRING, and every
-            # check that depends on `raw` quietly does nothing on one. The scale check —
+        elif not _NUM_RE.search(numeral_form(raw)):
+            # A `raw` WITH NO NUMBER IN IT IS NOT THE FIGURE'S PRINTED STRING. A count the
+            # slide SPELLS OUT ("three", "Fifteen years") is a number: `numeral_form` reads
+            # it as digits for every parser here, so it is validated rather than refused.
+            # What is refused is a raw with no magnitude at all -- and on one of those,
+            # every check that depends on `raw` quietly does nothing. The scale check —
             # the whole reason the field is required — needs a magnitude to compare, and
             # the date rule needs tokens to match against; both simply skip. So the one
             # guarantee `raw` carries is absent exactly where nothing announces it.

--- a/founder-skills/skills/deck-review/scripts/reconcile.py
+++ b/founder-skills/skills/deck-review/scripts/reconcile.py
@@ -191,6 +191,135 @@ def strip_group_marks(digits: str) -> str:
     return digits
 
 
+# SPELLED-OUT CARDINALS. Decks print small counts as words far more often than as digits --
+# "three design partners", "six patent applications", "fifteen years", "two founders" -- and
+# the extraction prompt says to record every number the deck states, with `raw` required to
+# be the slide's own printed string. The honest record of such a figure is `raw: "three"`,
+# and that was refused for "containing no number": the scale check had nothing to read, so
+# the guard was right to refuse rather than skip. It cost a repair dispatch on nearly every
+# real deck, and the smoke fixture that first hit it was edited to print "2" instead.
+#
+# So read the words. `numeral_form` rewrites the FIRST spelled-out cardinal as digits, and
+# ONLY when the string prints no digit at all -- a raw that already carries a numeral is the
+# figure's printed string and is left exactly as it is. Every grammar that parses `raw` reads
+# through it, so "three" gets the precision, scale and approximation treatment of "3" while
+# the printed string itself stays verbatim wherever a founder reads it.
+#
+# The grammar is deliberately narrow: cardinals below a thousand, joined by whitespace or
+# hyphens, with an optional article before "hundred". Scale WORDS are not consumed here --
+# `_NUM_RE` already reads "million" as a suffix, so "three million" becomes "3 million" and
+# is scaled by the same table every other grammar uses. Ordinals ("a fourth"), fractions and
+# "dozen" are left alone on purpose: they resemble a count and are not one, and a figure the
+# grammar does not read is still refused rather than guessed at.
+_WORD_VALUES: dict[str, int] = {
+    "zero": 0,
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+    "eleven": 11,
+    "twelve": 12,
+    "thirteen": 13,
+    "fourteen": 14,
+    "fifteen": 15,
+    "sixteen": 16,
+    "seventeen": 17,
+    "eighteen": 18,
+    "nineteen": 19,
+    "twenty": 20,
+    "thirty": 30,
+    "forty": 40,
+    "fifty": 50,
+    "sixty": 60,
+    "seventy": 70,
+    "eighty": 80,
+    "ninety": 90,
+}
+_WORD_TOKEN = re.compile(r"[A-Za-z]+")
+# What may sit between two words of one number: whitespace, a hyphen ("twenty-five"), or
+# nothing else. A comma or a full stop ends the number.
+_WORD_JOIN = re.compile(r"[\s\-\u2010\u2011]+")
+
+
+def _extends(current: int, word_value: int) -> bool:
+    """Does `word_value` continue the cardinal `current` ("twenty" -> "five", "hundred" -> "ten")?"""
+    if current >= 100 and current % 100 == 0:
+        return 0 < word_value < 100
+    tail = current % 100
+    return tail >= 20 and tail % 10 == 0 and 1 <= word_value <= 9
+
+
+def spelled_number(text: str) -> tuple[int, int, int] | None:
+    """The first spelled-out cardinal in `text`, as (value, start, end), or None."""
+    tokens = list(_WORD_TOKEN.finditer(text or ""))
+    for start, head in enumerate(tokens):
+        first = head.group().lower()
+        if first in ("a", "an"):
+            # "a hundred": the article is the mantissa, and only before "hundred".
+            if start + 1 < len(tokens) and tokens[start + 1].group().lower() == "hundred":
+                current, j = 1, start + 1
+            else:
+                continue
+        elif first in _WORD_VALUES:
+            current, j = _WORD_VALUES[first], start + 1
+        else:
+            continue
+        end = head.end()
+        while j < len(tokens):
+            nxt = tokens[j]
+            gap = text[tokens[j - 1].end() : nxt.start()]
+            word = nxt.group().lower()
+            if not _WORD_JOIN.fullmatch(gap) and not (word == "and" or gap.isspace()):
+                break
+            if word == "hundred" and 0 < current < 100:
+                current *= 100
+            elif word == "and":
+                # "one hundred and five": only between a whole hundred and its remainder.
+                follower = tokens[j + 1].group().lower() if j + 1 < len(tokens) else ""
+                if (
+                    current >= 100
+                    and current % 100 == 0
+                    and follower in _WORD_VALUES
+                    and _extends(current, _WORD_VALUES[follower])
+                ):
+                    j += 1
+                    continue
+                break
+            elif word in _WORD_VALUES and _extends(current, _WORD_VALUES[word]):
+                current += _WORD_VALUES[word]
+            else:
+                break
+            end = nxt.end()
+            j += 1
+        return current, head.start(), end
+    return None
+
+
+def numeral_form(raw: str) -> str:
+    """`raw` with its first spelled-out cardinal written in digits -- only when it prints none.
+
+    "Fifteen years" -> "15 years"; "about three" -> "about 3"; "a hundred customers" ->
+    "100 customers"; "three million" -> "3 million" (the scale word is left for `_NUM_RE`).
+    "$493K", "12 projects" and "a fourth" come back unchanged: the first two already print
+    a numeral, the last is an ordinal. Every parser of `raw` below reads through this, so a
+    spelled-out count is validated, scaled and bounded exactly as its digit form would be.
+    """
+    text = raw or ""
+    if _NUM_RE.search(text):
+        return text
+    found = spelled_number(text)
+    if found is None:
+        return text
+    value, start, end = found
+    return f"{text[:start]}{value}{text[end:]}"
+
+
 # Scientific notation, plain or superscript, written `e6`, `x10^6` or `×10⁶`.
 _EXPONENT = r"(?:[eE][-+]?(?P<eexp>\d+)|\s*[\u00d7xX*\u00b7]\s*10\s*\^?\s*(?P<exp>[-+]?[\d\u2070-\u209f]+))"
 
@@ -231,10 +360,11 @@ def _raw_scale(raw: str) -> float:
     tolerance of 0.5 on a figure denominated in thousands, 1000x too small, on a class
     that is 26% of every ledger.
     """
-    rng = _RANGE_RE.search(raw or "")
+    raw = numeral_form(raw)
+    rng = _RANGE_RE.search(raw)
     if rng and rng.group("suf"):
         return _SCALE.get(rng.group("suf").lower(), 1.0)
-    m = _NUM_RE.search(raw or "")
+    m = _NUM_RE.search(raw)
     if not m:
         return 1.0
     scale = _SCALE.get((m.group("suf") or "").lower(), 1.0)
@@ -258,7 +388,8 @@ def implied_tolerance(raw: str) -> float:
     reads the raw string, and the comparison runs on values -- `implied_tolerance
     ("(19,391)")` is 0.5 while the value being compared is 19,391,000.
     """
-    m = _NUM_RE.search(raw or "")
+    raw = numeral_form(raw)
+    m = _NUM_RE.search(raw)
     if not m:
         return 0.0
     decimals = len(m.group("frac") or "")
@@ -277,7 +408,7 @@ def _precision(raw: str) -> tuple[float, float] | None:
     Trailing zeros are NOT significant: "1,700" claims two figures and tolerates +/-50,
     while "1,696" claims four and tolerates +/-0.5.
     """
-    m = _NUM_RE.search(raw or "")
+    m = _NUM_RE.search(numeral_form(raw))
     if not m:
         return None
     ints = strip_group_marks(m.group("int") or "")
@@ -316,7 +447,7 @@ def parse_range(raw: str) -> tuple[float, float] | None:
     A trailing scale suffix binds to BOTH endpoints: "$150-250K" is 150k to 250k, not
     150 to 250,000.
     """
-    m = _RANGE_RE.search(raw or "")
+    m = _RANGE_RE.search(numeral_form(raw))
     if not m:
         return None
     scale = _SCALE.get((m.group("suf") or "").lower(), 1.0)
@@ -388,6 +519,7 @@ _APPROX_SYMBOLS = re.compile(r"[~≈]")
 
 def _approx_symbol_marks_this_figure(raw: str) -> bool:
     """Is there an approximation glyph before this figure's own number?"""
+    raw = numeral_form(raw)
     match = _NUM_RE.search(raw)
     if not match:
         return False
@@ -548,7 +680,7 @@ def detect_bound(raw: str, label: str, quote: str = "") -> str | None:
     # The LABEL is deliberately exempt: a label is prose ABOUT the figure, so "about 100
     # customers" as a label qualifies the figure it describes whether or not the label
     # itself repeats the number. `raw` is supposed to BE the figure's printed string.
-    raw_word_binds = bool(_APPROX_WORDS.search(raw) and _NUM_RE.search(raw))
+    raw_word_binds = bool(_APPROX_WORDS.search(raw) and _NUM_RE.search(numeral_form(raw)))
     if (
         _approx_symbol_marks_this_figure(raw)
         or raw_word_binds

--- a/founder-skills/tests/test_ledger.py
+++ b/founder-skills/tests/test_ledger.py
@@ -52,37 +52,76 @@ def _run(payload: dict, extra: list[str] | None = None) -> tuple[int, str, str]:
     return res.returncode, res.stdout, res.stderr
 
 
-def test_rejects_a_word_number_as_raw() -> None:
-    """`raw` must be the slide's printed string, and a spelled-out count is not one.
+def _word_count_fig(raw: str, value: float, **over: object) -> dict:
+    fig = _fig(
+        id="founder_count",
+        value=value,
+        raw=raw,
+        unit_kind="count",
+        currency=None,
+        quote="Two founders, ex-Stripe and ex-Notion",
+    )
+    fig.update(over)
+    return fig
 
-    Found by a live run, not by this file: the `deck-review-smoke` fixture said "Two
-    founders", the extractor recorded `raw: "Two"`, and the guard at ledger.py:347 rejected
-    it correctly — costing a repair dispatch that blew the scenario's sub-agent budget. The
-    guard worked; it simply had NO test, so nothing here would have caught its removal.
 
-    The rejection matters beyond tidiness, per the guard's own note: a numeral-free `raw`
-    reads downstream as an approximation and widens tolerance, which once turned a summed
-    108 against a stated 100 from a contradiction into a confirmation.
+def test_accepts_a_spelled_out_count_the_slide_prints() -> None:
+    """`raw` must be the slide's printed string — and when the slide prints "Two", that IS it.
 
-    The fixture now says "2 co-founders" — the figure is kept, the trap is gone, and this
-    test holds the behaviour instead of a paid run holding it.
+    History: this guard used to REJECT a spelled-out count. Found by a live run, not by this
+    file: the `deck-review-smoke` fixture said "Two founders", the extractor recorded
+    `raw: "Two"`, and the guard refused it as "containing no number" — costing a repair
+    dispatch that blew the scenario's sub-agent budget. The fixture was edited to print "2"
+    instead, which fixed the fixture and left every real deck: measured on one, "three
+    production R&D organizations", "Six patent applications filed", "Fifteen years" and
+    "Five people" were all either refused (one run) or silently dropped (the next, once the
+    extractor had learned to avoid the refusal). Neither outcome records what the deck says.
+
+    The guard's own reasons for refusing were real — a numeral-free `raw` gave the scale check
+    nothing to compare and read downstream as an approximation, widening tolerance — and both
+    are answered by reading the words: `numeral_form` gives every parser "2" where the slide
+    printed "Two", so the figure is validated, scaled and bounded exactly as its digit form.
     """
+    rc, _, err = _run({"figures": [_fig(), _word_count_fig("Two", 2)]})
+    assert rc == 0, err
+
+
+def test_rejects_a_spelled_out_count_whose_value_disagrees() -> None:
+    """Reading the words is what makes the scale check RUN on them — so it has to catch this."""
+    rc, _, err = _run({"figures": [_fig(), _word_count_fig("Two", 3)]})
+    assert rc != 0, "raw 'Two' with value 3 passed — the spelled-out count was accepted unread"
+    assert "disagrees with raw" in err, err
+
+
+def test_a_spelled_out_count_keeps_its_unit_word() -> None:
+    """ "Fifteen years" is 15 with the unit left in place, the same as "15 years"."""
     rc, _, err = _run(
         {
             "figures": [
                 _fig(),
-                _fig(
-                    id="founder_count",
-                    value=2,
-                    raw="Two",
-                    unit_kind="count",
-                    currency=None,
-                    quote="Two founders, ex-Stripe and ex-Notion",
+                _word_count_fig(
+                    "Fifteen years", 15, id="ceo_tenure", unit_kind="duration", quote="Fifteen years on executive teams"
                 ),
             ]
         }
     )
-    assert rc != 0, "a spelled-out count passed as the slide's printed string"
+    assert rc == 0, err
+
+
+def test_a_compound_spelled_out_number_is_read_whole() -> None:
+    """ "Twenty-five" is 25, not 20 — and a hyphen or a space joins the two words equally."""
+    for raw in ("Twenty-five", "twenty five"):
+        rc, _, err = _run({"figures": [_fig(), _word_count_fig(raw, 25, quote="Twenty-five design partners")]})
+        assert rc == 0, f"{raw!r}: {err}"
+        rc, _, err = _run({"figures": [_fig(), _word_count_fig(raw, 20, quote="Twenty-five design partners")]})
+        assert rc != 0, f"{raw!r} accepted as 20"
+
+
+def test_an_ordinal_is_still_not_a_number() -> None:
+    """ "a fourth" names a position, not a count. The grammar does not read it, so the figure is
+    refused rather than guessed at — same as any other raw with no magnitude in it."""
+    rc, _, err = _run({"figures": [_fig(), _word_count_fig("a fourth", 4, quote="a fourth in agreements")]})
+    assert rc != 0
     assert "contains no number" in err, err
 
 

--- a/founder-skills/tests/test_reconcile.py
+++ b/founder-skills/tests/test_reconcile.py
@@ -1543,3 +1543,71 @@ def test_untested_claims_survive_into_the_artifact_even_though_the_relation_does
         "founder is told their figures line up about a claim that was never checked"
     )
     assert any("4x" in c for c in artifact["untested_claims"]), artifact["untested_claims"]
+
+
+# --- spelled-out cardinals ---------------------------------------------------------------
+#
+# `numeral_form` is what lets a raw of "three" reach the same precision, scale, range and
+# approximation checks as "3". It rewrites ONLY when the string prints no digit; a raw that
+# already carries a numeral is the figure's printed string and must come back untouched.
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Fifteen years", "15 years"),
+        ("Six", "6"),
+        ("three", "3"),
+        ("Twenty-five percent", "25 percent"),
+        ("twenty five", "25"),
+        ("a hundred customers", "100 customers"),
+        ("one hundred and five", "105"),
+        ("about three", "about 3"),
+        ("three million", "3 million"),  # the scale word is `_NUM_RE`'s to read
+        ("zero", "0"),
+        ("$493K", "$493K"),  # prints a digit: untouched
+        ("12 projects", "12 projects"),
+        ("three of the 500", "three of the 500"),  # a digit anywhere wins; the words are prose
+        ("a fourth", "a fourth"),  # ordinal
+        ("hundred", "hundred"),  # no mantissa
+        ("TBD", "TBD"),
+        ("", ""),
+    ],
+)
+def test_numeral_form_reads_spelled_out_cardinals_only_where_no_digit_is_printed(raw: str, expected: str) -> None:
+    from reconcile import numeral_form
+
+    assert numeral_form(raw) == expected
+
+
+def test_a_spelled_out_count_has_the_precision_and_scale_of_its_digit_form() -> None:
+    from reconcile import _precision, _raw_scale, implied_tolerance
+
+    assert _precision("three") == _precision("3")
+    assert _precision("Fifteen years") == _precision("15 years")
+    assert _raw_scale("three million") == _raw_scale("3 million") == 1e6
+    assert implied_tolerance("Twenty-five") == implied_tolerance("25")
+
+
+def test_a_spelled_out_count_is_bounded_like_its_digit_form() -> None:
+    """The word path in `detect_bound` requires a number to bind to — and now it finds one.
+
+    `raw="about"` alone stays unbound (that hole is closed upstream by ledger.py's refusal), but
+    "about three" is an approximation of three, exactly as "about 3" is.
+    """
+    from reconcile import detect_bound
+
+    assert detect_bound("three", "design partners") is None
+    assert detect_bound("about three", "design partners") == "approximate"
+    assert detect_bound("about 3", "design partners") == "approximate"
+    assert detect_bound("about", "design partners") is None
+    assert (
+        detect_bound("over three", "design partners") is None
+    )  # the leading-word bound grammar wants a digit; unchanged
+
+
+def test_a_spelled_out_range_is_a_range() -> None:
+    from reconcile import parse_range
+
+    assert parse_range("three-five") is None  # only the first cardinal is rewritten; a word range is not read
+    assert parse_range("3-5") == (3.0, 5.0)

--- a/founder-skills/tests/test_skill_contract.py
+++ b/founder-skills/tests/test_skill_contract.py
@@ -900,7 +900,15 @@ SKILL_MD_CEILING: dict[str, int] = {
     # rescoped to "you never write a canonical artifact" across all 22 sites (W2 audit). The
     # instruction was always correct; the REASON given for it asserted the general claim P0-2
     # established is false — the main thread writes several canonical artifacts by heredoc.
-    "deck-review": 102_180,
+    # deck-review 102,180 -> 102,508 (+328): the LEDGER_EXTRACTION template now says a count
+    # the slide spells out in words IS a figure, recorded with the words as printed. Measured on a
+    # real deck across two runs: "three production R&D organizations", "Six patent applications",
+    # "Fifteen years" and "Five people" were refused by ledger.py on the first ("contains no
+    # number", a repair dispatch) and silently omitted on the second, once the extractor had
+    # learned to avoid the refusal. ledger.py now reads spelled-out cardinals through
+    # `numeral_form`, so the instruction and the validator agree; without the sentence the model
+    # keeps choosing between the two failures, and neither records what the deck says.
+    "deck-review": 102_508,
     # competitive-positioning: + the merge step's "positioning_scores.json is aggregates only" claim
     # corrected. It is false — score_positioning.py passes points[] straight through — and that false
     # premise is plausibly why the merge was never cross-checked. Compose now checks it.

--- a/founder-skills/tests/test_skill_contract.py
+++ b/founder-skills/tests/test_skill_contract.py
@@ -908,7 +908,15 @@ SKILL_MD_CEILING: dict[str, int] = {
     # learned to avoid the refusal. ledger.py now reads spelled-out cardinals through
     # `numeral_form`, so the instruction and the validator agree; without the sentence the model
     # keeps choosing between the two failures, and neither records what the deck says.
-    "deck-review": 102_508,
+    # deck-review 102,508 -> 104,641 (+2133): the PowerPoint conversion block tries three converters
+    # instead of one — LibreOffice (any OS), then Keynote on macOS, then PowerPoint over COM on
+    # Windows — each only where it is installed, and falls through to the text-only path otherwise.
+    # Claude Code hosts are laptops, and a laptop without LibreOffice is the common case; measured on
+    # a Mac, the whole design category was gated to not_applicable with Keynote sitting in
+    # /Applications. Two of the three are inline scripts (AppleScript, PowerShell), which is where
+    # the bytes are: a converter the skill only names, without the invocation, is one the model
+    # improvises — and the improvised Keynote script is what failed on the run that measured this.
+    "deck-review": 104_641,
     # competitive-positioning: + the merge step's "positioning_scores.json is aggregates only" claim
     # corrected. It is false — score_positioning.py passes points[] straight through — and that false
     # premise is plausibly why the merge was never cross-checked. Compose now checks it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "founder-skills"
-version = "0.11.0"
+version = "0.11.1"
 license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## What

Two deck-review defects measured on one real pre-seed deck (a 19-slide `.pptx`), run twice through the skill in Claude Code on a Mac. Two commits, one per defect; `0.11.0 → 0.11.1` with a changelog entry.

**1. `fix`: counts the deck spells out in words are refused, then silently dropped.**
The LEDGER_EXTRACTION prompt says to record every number the deck states with `raw` as the slide's own printed string. The deck prints "three production R&D organizations", "Six patent applications filed", "Fifteen years", "Five people". The honest record is `raw: "three"`, and `ledger.py` refused it as "contains no number" — a repair dispatch on the first run. On the second run the extractor had learned to avoid the refusal and omitted every spelled-out figure: slide 2 (team) contributed no figures at all, and the founder count, patent count and CEO tenure never reached the numbers section. The smoke fixture hit the same guard earlier and was edited to print "2" instead (`test_rejects_a_word_number_as_raw`'s docstring), which fixed the fixture and left real decks.

The guard's reasons were valid — the scale check had nothing to read, and a numeral-free `raw` read downstream as an approximation — so the fix reads the words rather than dropping the guard. `reconcile.py` gains `numeral_form`, which rewrites the first spelled-out cardinal as digits (below a thousand; "a hundred", "twenty-five", "one hundred and five"; "three million" keeps the scale word for the existing suffix table) **only when the raw prints no digit**. Every parser of `raw` reads through it — `_parsed_magnitude`, `_numeric_tokens`, `_precision`, `_raw_scale`, `implied_tolerance`, `parse_range`, the approximation-glyph and word binding, `_ambiguous_suffix` — so "three" is validated, scaled and bounded exactly as "3", while `Figure.raw` and every rendered line keep the words. "about", "TBD" and the ordinal "a fourth" are still refused. The dispatch template and the agent body now state the rule.

Re-run on the same deck with the amended prompt: 18 spelled-out figures recorded; the shipped `ledger.py` refuses four of them, the patched one accepts all 168 and `reconcile.py` runs on them.

**2. `feat`: PowerPoint conversion when LibreOffice is absent.**
Step 2 converts `.pptx` to PDF so the design criteria can be scored; only LibreOffice was known, so on this Mac the whole Design & Readability category went `not_applicable` with Keynote in `/Applications`. The block now tries three converters, each **only where installed**: LibreOffice (any OS, now including the default Windows path), Keynote via AppleScript on macOS, PowerPoint via COM from PowerShell on Windows. A host with none of them takes the existing text-only path unchanged. The Keynote invocation is the one that worked on the measured run (a stale headless Keynote answers `-1708` to every document command; `launch` first, then open, wait, export). **The PowerPoint path follows Microsoft's documented `Presentations.Open` / `SaveAs(…, ppSaveAsPDF)` automation and has not been exercised on a Windows host by me** — said so in the changelog; happy to drop it to a follow-up if you would rather not merge an unexercised branch.

`SKILL.md` byte cap raised twice with the usual ledger comments (`102,180 → 102,508 → 104,641`).

## Related issue

None filed — found by running the skill.

## Checklist

- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run mypy` passes for affected skill directories (`deck-review/scripts`, `tests/`)
- [x] `uv run pytest` passes (5273 passed, 25 skipped, 34 deselected; `-m "not e2e and not mutation"`)
- [x] `cowork-harness analyze-skill founder-skills/ --strict` and `lint-skill founder-skills/skills/deck-review/ --strict` pass (0 errors, 0 warnings; 1 pre-existing info)
- [x] `uv run pytest -m cowork` — cassette replay ran as part of the full suite above
- [x] Commits are signed off (`git commit -s`) per DCO
- [ ] New skills include: SKILL.md, agent definition, tests, and reference files — n/a
